### PR TITLE
Update examples middleware functions to show current state of package

### DIFF
--- a/examples/next-auth/src/middleware.ts
+++ b/examples/next-auth/src/middleware.ts
@@ -8,24 +8,33 @@ import {
 
 const middlewares = {
   '/page1': [
-    async ({ request }: MiddlewareFunctionProps) => {
+    async ({ request, forward }: MiddlewareFunctionProps) => {
       console.log('Middleware for /page1', request.nextUrl.pathname);
-      return NextResponse.next();
+      const response = NextResponse.next();
+      response.headers.set('x-page1-header', 'page1-value');
+      forward(response);
+    },
+    async ({ request }: MiddlewareFunctionProps) => {
+      console.log('Chained middleware for /page1', request.nextUrl.pathname);
+      console.log('Page1 header value:', request.headers.get('x-page1-header'));
     },
   ],
   '/page2': [
-    async ({ request }: MiddlewareFunctionProps) => {
+    async ({ request, forward }: MiddlewareFunctionProps) => {
       if (await auth(request as never)) {
-        return NextResponse.next();
+        const response = NextResponse.next();
+        response.headers.set('x-authenticated', 'true');
+        forward(response);
+      } else {
+        return NextResponse.json(
+          { success: false, message: 'Unauthorized' },
+          { status: 401 },
+        );
       }
-
-      return NextResponse.json(
-        { success: false, message: 'Unauthorized' },
-        { status: 401 },
-      );
     },
     async ({ request }: MiddlewareFunctionProps) => {
       console.log('Middleware for /page2', request.nextUrl.pathname);
+      console.log('Authenticated header value:', request.headers.get('x-authenticated'));
       return NextResponse.redirect('http://localhost:3002/page1');
     },
   ],


### PR DESCRIPTION
Update middleware functions in `examples/next-auth/src/middleware.ts` to reflect the current state of the package.

* **Middleware for `/page1`**
  - Add `forward` parameter to middleware function.
  - Set custom header `x-page1-header` in the response.
  - Add chained middleware to log the custom header value.

* **Middleware for `/page2`**
  - Add `forward` parameter to middleware function.
  - Set custom header `x-authenticated` in the response if authentication is successful.
  - Return JSON response with status 401 if authentication fails.
  - Log the custom header value in the second middleware function.

