### PR TITLE
Conditionally render canary banner based on environment

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -42,10 +42,12 @@ export default function Layout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <body>
-        <Banner variant="rainbow">
-          This is `canary` version of documentation. It&apos;s still under
-          construction and review.
-        </Banner>
+        {process.env.NEXT_PUBLIC_VERCEL_ENV !== "production" && (
+          <Banner variant="rainbow">
+            This is `canary` version of documentation. It&apos;s still under
+            construction and review.
+          </Banner>
+        )}
         <RootProvider
           search={{
             options: {


### PR DESCRIPTION
Render the canary banner only in non-production environments to avoid confusion for users.