### PR TITLE
chore: sync main back into canary before the 3.0.0 release

### DIFF
--- a/.changeset/bump-minor-version.md
+++ b/.changeset/bump-minor-version.md
@@ -1,5 +1,0 @@
----
-"@rescale/nemo": minor
----
-
-Minor version bump

--- a/packages/nemo/CHANGELOG.md
+++ b/packages/nemo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NEMO
 
+## 2.2.0
+
+### Minor Changes
+
+- 9dc114b: Minor version bump
+
 ## 2.1.1
 
 ### Patch Changes

--- a/packages/nemo/package.json
+++ b/packages/nemo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rescale/nemo",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "keywords": [
     "Next.js",
     "Middleware",


### PR DESCRIPTION
Preparation for the `canary` → `main` release merge. **Not the release itself.**

`main` released 2.2.0 back in March and was never merged back, so `canary` still carries 2.1.1.
Merging `canary` into `main` as-is would regress the version and drop the 2.2.0 changelog entry.
This syncs the other direction first, which is the pattern the repo already used (`Merge branch
'main' into canary`).

## What the merge did

- **`packages/nemo/package.json`** — the only conflict, and the meaningful one. Took the **name**
  from canary (`@zanreal/nemo`, the rename) and the **version** from main (`2.2.0`, what is
  actually on npm).
- **`packages/rescale-nemo`** — aligned to `2.2.0` too. It carries the published `@rescale/nemo`
  line, so starting it anywhere else would misstate the history.
- **CHANGELOG** — auto-merged; the 2.2.0 entry is back.
- **`.changeset/bump-minor-version.md`** — correctly deleted by the merge. It was consumed by the
  2.2.0 release on main but was still sitting on canary, where it would have been applied a
  second time.

## Release this sets up

`changeset version` dry run against the synced tree:

```
@zanreal/nemo          3.0.0
@rescale/nemo          3.0.0   (fixed group, tracks the above)
@zanreal/nemo-codemod  1.0.0
```

272 tests pass, build clean.

## Two blockers before `canary` → `main`

Merging to `main` triggers `release.yml`, which publishes. Both of these must be cleared first,
because npm versions cannot be reused once burned.

**1. The repository has not been transferred yet.** It is still `z4nr34l/nemo`, while
`package.json` already declares `repository: github.com/zanreal-labs/nemo` and
`publishConfig.provenance: true`. npm's requirement:

> Ensure your `package.json` is configured with a public `repository` that matches
> (case-sensitive) where you are publishing with provenance from.

So publishing from `z4nr34l/nemo` with that repository field is expected to **fail provenance**,
not merely record a wrong URL. Transfer to `zanreal-labs` first.

**2. `NPM_TOKEN` needs write access to the `@zanreal` scope.** It has only ever published to
`@rescale`. If it lacks the scope, the publish fails partway — and because `@zanreal/nemo` and
`@rescale/nemo` are a `fixed` group, a partial publish leaves the alias pointing at a version of
the real package that does not exist on the registry.

Also worth confirming after the transfer, since `main` requires them: **Codecov** (`Codecov`,
`codecov/patch`, `codecov/project`) and **Vercel** are required checks on `main`, and both are
third-party apps that need access on the new org.