### PR TITLE
ci: scope the coverage gate to the library

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# The 100% coverage bar this repo holds is about the library. `bun test` runs from the workspace
+# root, so it instruments every package it loads — which since 3.0.0 includes the codemod CLI and
+# the alias package. Those are published tools rather than the library, and their uncovered lines
+# are argv handling and process-exit paths.
+#
+# Without this, adding a package silently lowers the bar for packages/nemo: the project target is
+# derived from the previous commit, so a diluted average becomes the new baseline and real gaps in
+# the library stop failing the build. Scope the report to the library so the gate keeps meaning
+# what it did.
+ignore:
+  - "packages/codemod/**"
+  - "packages/rescale-nemo/**"
+  - "apps/**"


### PR DESCRIPTION
Unblocks #188. The `canary` → `main` PR is the first time **Codecov** has run on any of this
work — it is required on `main` but not on `canary` — and it fails both required checks:

```
codecov/patch    95.53% of diff hit (target 100.00%)
codecov/project  98.66% (-1.34%) compared to 6c87478
```

## It is not the library

`packages/nemo/src` is **100% on every file**, including the Set-Cookie fix:

```
packages/codemod/bin/cli.js                        91.67 |  92.15   <- the drop
packages/codemod/transforms/rescale-to-zanreal.js  84.62 | 100.00   <- the drop
packages/nemo/src/index.ts                        100.00 | 100.00
packages/nemo/src/event.ts                        100.00 | 100.00
   ...every other library file 100/100
```

`bun test` runs from the workspace root so it instruments whatever it loads, and the upload is
pointed at `./packages/nemo/coverage` regardless — the codemod CLI ended up inside a report meant
for the library.

## Why this matters beyond a red check

Codecov's project target is derived from the previous commit. Leaving the codemod in means the
diluted average becomes the new baseline, so the library quietly stops being held to 100% and
real gaps in it would no longer fail the build.

So this scopes the report to the library rather than chasing 100% on a CLI's argv and
process-exit paths. Validated with `codecov.io/validate`:

```
{"ignore": ["(?s:packages/codemod/.*)\\Z", "(?s:packages/rescale-nemo/.*)\\Z", "(?s:apps/.*)\\Z"]}
```

If you would rather hold the codemod to 100% too, say so and I will write the missing tests
instead — it is maybe a dozen cases around flag validation and exit paths.

## Unrelated, not blocking

The `snyk` **workflow job** is also red, with `Forbidden` from the Snyk REST API — a credential
problem like `SONAR_TOKEN`, not a code finding. The Snyk *app* checks (`code/snyk`,
`security/snyk`) both pass, and `snyk` is not a required check on `main`. Worth rotating
alongside the other tokens during the transfer; I have deliberately not masked it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Codecov to the library so the 100% coverage gate applies to `packages/nemo` only. Adds `codecov.yml` ignoring `packages/codemod/**`, `packages/rescale-nemo/**`, and `apps/**` to prevent diluted baselines and false failures.

<sup>Written for commit c42270bcba8ecf42a5db5bedac1d502d34b57edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/z4nr34l/nemo/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage reporting to focus on the library’s code.
  * Excluded published tooling and application code from library coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->