### PR TITLE
ci: make the coverage statuses base-independent

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,23 @@ ignore:
   - "packages/codemod/**"
   - "packages/rescale-nemo/**"
   - "apps/**"
+
+coverage:
+  status:
+    # Absolute targets rather than `auto`. `auto` compares against the base commit, and the move
+    # to the zanreal-labs organisation reset Codecov's history for this repo — `codecov/patch`
+    # reported "No report found to compare against" and `codecov/project` was not posted at all.
+    # Both are required checks on main, so a status that silently declines to post deadlocks the
+    # release: no base until something lands on main, and nothing can land without the status.
+    #
+    # Stating the target outright also documents the invariant instead of inferring it from
+    # whatever the previous commit happened to score.
+    project:
+      default:
+        target: 100%
+        threshold: 0%
+        if_not_found: success
+    patch:
+      default:
+        target: 100%
+        if_not_found: success


### PR DESCRIPTION
Unblocks #188. Follow-up to #189 — that scoped the report correctly, but a second problem was
hiding behind the first.

## The deadlock

The transfer reset Codecov's history for this repo. On #188:

```
codecov/patch    success — "No report found to compare against"
codecov/project  (not posted at all)
```

Both are **required checks on `main`**. A required status that never posts cannot be satisfied,
and the way out is circular: `project` needs a base report, a base report needs a commit on
`main`, and nothing reaches `main` without the status.

## Fix

Absolute targets instead of the implicit `auto`, plus `if_not_found: success`, so both statuses
evaluate current coverage rather than a comparison that no longer exists.

100% is not aspirational — every file under `packages/nemo/src` is 100/100 today, and with the
codemod ignored that is precisely what the project status measures:

```
packages/nemo/src/index.ts    100.00 | 100.00
packages/nemo/src/event.ts    100.00 | 100.00
   ...every library file 100/100
```

Stating the target outright also fixes what made the original failure hard to spot: `auto`
infers the bar from whatever the last commit scored, so the bar drifts silently.

Validated with `codecov.io/validate`.

## Still needs you — two required checks cannot be fixed from the repo

`Socket Security: Project Report` and `Socket Security: Pull Request Alerts` are required on
`main` but **stopped reporting after the transfer**. Comparing the app installations on
`zanreal-labs`:

```
installed:      vercel, codecov, sonarqubecloud, pkg-pr-new, claude, sentry, linear, ...
NOT installed:  socket-security, snyk, coderabbitai, cubic-dev-ai
```

They reported fine on #188 before the transfer, so this is purely the app not being installed on
the new organisation. #188 stays blocked until either Socket Security is installed on
`zanreal-labs`, or those two contexts are dropped from `main`'s protection rules.

Snyk, CodeRabbit and cubic are in the same position but are not required, so they only cost you
review coverage rather than blocking the release.