### PR TITLE
release: 3.0.1 — repair the uninstallable @rescale/nemo alias

### DIFF
--- a/.changeset/fix-alias-workspace-protocol.md
+++ b/.changeset/fix-alias-workspace-protocol.md
@@ -1,0 +1,25 @@
+---
+"@zanreal/nemo": patch
+---
+
+Fix `@rescale/nemo` being uninstallable at 3.0.0.
+
+The alias declared its dependency on the library as `"@zanreal/nemo": "workspace:^"`. That
+protocol is supposed to be rewritten to a real semver range when the package is published, but
+the rewrite did not happen and the literal specifier reached the registry, so npm refuses to
+install it:
+
+```
+npm error code EUNSUPPORTEDPROTOCOL
+npm error Unsupported URL Type "workspace:": workspace:^
+```
+
+A bare `npm install @rescale/nemo` was unaffected — npm skipped the unresolvable version and
+resolved 2.2.0 — but anything pinning `@3` or `@^3` failed outright, on the package whose entire
+job is to keep existing installs working.
+
+The dependency is now a literal `^3.0.0`. Local development is unchanged: the workspace still
+links `packages/nemo` because its version satisfies the range.
+
+Both packages move together as a `fixed` group, so this releases `@zanreal/nemo` too; that
+version is identical to 3.0.0 in content.

--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
     },
     "packages/codemod": {
       "name": "@zanreal/nemo-codemod",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "bin": {
         "nemo-codemod": "./bin/cli.js",
       },
@@ -79,7 +79,7 @@
     },
     "packages/nemo": {
       "name": "@zanreal/nemo",
-      "version": "2.1.1",
+      "version": "3.0.0",
       "dependencies": {
         "path-to-regexp": "^6.1.0",
       },
@@ -113,7 +113,7 @@
     },
     "packages/rescale-nemo": {
       "name": "@rescale/nemo",
-      "version": "2.1.1",
+      "version": "3.0.0",
       "dependencies": {
         "@zanreal/nemo": "workspace:^",
       },

--- a/packages/rescale-nemo/__tests__/manifest.test.ts
+++ b/packages/rescale-nemo/__tests__/manifest.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guards the published manifests.
+ *
+ * @rescale/nemo@3.0.0 shipped with `"@zanreal/nemo": "workspace:^"` in its dependencies. The
+ * workspace protocol is meant to be rewritten to a real range at publish time; under bun it was
+ * not, so the literal specifier reached the registry and npm rejects it:
+ *
+ *     npm error code EUNSUPPORTEDPROTOCOL
+ *     npm error Unsupported URL Type "workspace:": workspace:^
+ *
+ * That made the compatibility alias — the whole point of which is that existing installs keep
+ * working — uninstallable. Nothing in the test suite or the release dry run covered it, because
+ * both stop at `changeset version`; the defect only exists in the artifact.
+ */
+
+const root = join(import.meta.dir, "..", "..", "..");
+const manifest = (path: string) =>
+  JSON.parse(readFileSync(join(root, path, "package.json"), "utf8"));
+
+/** Packages that actually get published, i.e. the ones whose manifests reach consumers. */
+const PUBLISHABLE = ["packages/nemo", "packages/rescale-nemo", "packages/codemod"];
+
+const DEPENDENCY_BLOCKS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+describe("published manifests", () => {
+  test.each(PUBLISHABLE)("%s declares no workspace: protocol", (path) => {
+    const pkg = manifest(path);
+
+    const offenders = DEPENDENCY_BLOCKS.flatMap((block) =>
+      Object.entries(pkg[block] ?? {})
+        .filter(([, range]) => String(range).startsWith("workspace:"))
+        .map(([name, range]) => `${block}.${name} = ${range}`),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  // The two are a changesets `fixed` group, so a future major bumps both together. Without this
+  // the alias would keep a stale `^3.0.0` while itself being published as 4.x — installable, but
+  // resolving to the wrong library.
+  test("the alias depends on the current major of the library", () => {
+    const library = manifest("packages/nemo");
+    const alias = manifest("packages/rescale-nemo");
+
+    const range = alias.dependencies["@zanreal/nemo"];
+    expect(range).toBeDefined();
+
+    const majorOf = (value: string) => value.replace(/^[^0-9]*/, "").split(".")[0];
+
+    expect(majorOf(range)).toBe(majorOf(library.version));
+  });
+
+  test("the alias points at the library by name", () => {
+    const library = manifest("packages/nemo");
+    const alias = manifest("packages/rescale-nemo");
+
+    expect(Object.keys(alias.dependencies)).toEqual([library.name]);
+  });
+});

--- a/packages/rescale-nemo/package.json
+++ b/packages/rescale-nemo/package.json
@@ -51,7 +51,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@zanreal/nemo": "workspace:^"
+    "@zanreal/nemo": "^3.0.0"
   },
   "peerDependencies": {
     "next": ">=13.0.0"


### PR DESCRIPTION
Carries #192 to release. Merging publishes:

```
@zanreal/nemo   3.0.0 -> 3.0.1   (fixed group; content-identical to 3.0.0)
@rescale/nemo   3.0.0 -> 3.0.1   (the actual fix)
```

## Why

`@rescale/nemo@3.0.0` shipped with `"@zanreal/nemo": "workspace:^"` — the publish-time rewrite
never happened, and npm rejects the literal protocol:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

`latest` points at that version. Bare installs fall back to 2.2.0, so the existing base is fine,
but every `@3` / `@^3` pin fails — on the compatibility alias whose whole job is not breaking
people. npm versions are immutable, so 3.0.1 supersedes rather than repairs.

3.0.1's manifest was verified at the artifact level before this PR: guard test proven in both
directions, and the packed tarball's manifest reads `{"@zanreal/nemo": "^3.0.0"}` with no
workspace protocol.

## Release mechanics

One changeset is pending, so the release workflow will want to open a "Version Packages" PR
first. If **Org → Actions → "Allow GitHub Actions to create and approve pull requests"** is still
disabled it will fail at that step, same as yesterday, and the PR needs opening by hand.

After 3.0.1 is live: `latest` moves automatically, and the outstanding post-release items
remain — `npm deprecate "@rescale/nemo@<=2.2.0"`, plus deprecating the broken 3.0.0 specifically:
`npm deprecate "@rescale/nemo@3.0.0" "Uninstallable due to a workspace: protocol leak — use 3.0.1"`.