### PR TITLE
fix: robots.txt pointed the sitemap at a 404

### DIFF
--- a/apps/docs/app/robots.ts
+++ b/apps/docs/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: url("/sitemap"),
+    sitemap: url("/sitemap.xml"),
   };
 }


### PR DESCRIPTION
Found while checking crawlability ahead of the eventual nemo.zanreal.com -> zanreal.com/docs/nemo
domain move — not blocking, just a real bug worth fixing on its own.

## The bug

`app/robots.ts` declared the sitemap at `/sitemap`:

```ts
sitemap: url("/sitemap"),
```

But Next's file convention serves `app/sitemap.ts` at `/sitemap.xml`, not `/sitemap`. Every
crawler reading robots.txt was being pointed at a 404 for sitemap discovery.

```
curl https://nemo.zanreal.com/sitemap        -> 404
curl https://nemo.zanreal.com/sitemap.xml    -> 200, real entries
```

## Fix

One line: `url("/sitemap")` -> `url("/sitemap.xml")`. Verified against the built output —
`robots.txt.body` now reads `Sitemap: https://nemo.zanreal.com/sitemap.xml`.

Unrelated positive finding from the same check: the Attack Challenge Mode 429 on
nemo.zanreal.com is gone (`curl -I` now returns a clean 200), and the production build no
longer shows the canary banner — that's correctly gated on `NEXT_PUBLIC_VERCEL_ENV`.