### PR TITLE
fix: robots.txt sitemap URL (docs)

### DIFF
--- a/apps/docs/app/robots.ts
+++ b/apps/docs/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: url("/sitemap"),
+    sitemap: url("/sitemap.xml"),
   };
 }


### PR DESCRIPTION
Ships #195 to production. `apps/docs/app/robots.ts` declared the sitemap at `/sitemap`, but
Next's file convention serves `app/sitemap.ts` at `/sitemap.xml` — every crawler reading
robots.txt was being sent to a dead URL for sitemap discovery.

```diff
-      sitemap: url("/sitemap"),
+      sitemap: url("/sitemap.xml"),
```

Verified against the live site and the built output: `/sitemap` returned 404, `/sitemap.xml`
returns 200 with real entries.

## No package release

`apps/docs` is in `.changeset/config.json`'s `ignore` list, so this carries no changeset and
`release.yml` will not publish anything — merging just updates `main` and lets Vercel deploy the
docs fix to production.

Trial-merged locally first: clean, no conflicts. `main` currently has 3 commits `canary` lacks
(the 3.0.1 release commits from #193/#194) — those stay on `main` only, same as the March 2.2.0
release; they get folded back into `canary` on the next `main`-sync PR, not this one.