### PR TITLE
docs: write meta descriptions as search snippets, not sidebar subtitles

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Compose several Next.js middlewares behind one entry point and dispatch them by path.
+description: Compose several Next.js middlewares behind one entry point and dispatch them by path - configuration, shared storage and ready-made integrations.
 ---
 
 <DocsHero

--- a/docs/index.pl.mdx
+++ b/docs/index.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wprowadzenie
-description: Wiele funkcji middleware w Next.js za jednym punktem wejścia, rozdzielanych po ścieżkach.
+description: Wiele funkcji middleware w Next.js za jednym punktem wejścia, rozdzielanych po ścieżkach - konfiguracja, storage i gotowe integracje.
 ---
 
 <DocsHero

--- a/docs/latest/3rd-parties/next-auth.mdx
+++ b/docs/latest/3rd-parties/next-auth.mdx
@@ -1,6 +1,6 @@
 ---
 title: NextAuth (Auth.js)
-description: NEMO middleware functions for NextAuth (Auth.js)
+description: Wire Auth.js into a NEMO chain so the session it resolves is available to every function that runs after it, without a second lookup per request.
 icon: SquareFunction
 ---
 

--- a/docs/latest/3rd-parties/next-auth.pl.mdx
+++ b/docs/latest/3rd-parties/next-auth.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: NextAuth (Auth.js)
-description: Jak udostępnić sesję Auth.js pozostałym funkcjom w łańcuchu NEMO
+description: Jak wpiąć Auth.js w łańcuch NEMO, żeby sesja rozwiązana raz była dostępna dla wszystkich kolejnych funkcji bez ponownego odpytywania bazy.
 icon: SquareFunction
 ---
 

--- a/docs/latest/3rd-parties/supabase.mdx
+++ b/docs/latest/3rd-parties/supabase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supabase
-description: NEMO middleware functions for Supabase
+description: Run Supabase session refresh inside a NEMO chain, so refreshed cookies reach the response and the functions after it see the signed-in user.
 icon: SquareFunction
 ---
 

--- a/docs/latest/3rd-parties/supabase.pl.mdx
+++ b/docs/latest/3rd-parties/supabase.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supabase
-description: Jak wpiąć odświeżanie sesji Supabase w łańcuch middleware NEMO
+description: Odświeżanie sesji Supabase wewnątrz łańcucha NEMO: ciasteczka trafiają do odpowiedzi, a kolejne funkcje widzą już zalogowanego użytkownika.
 icon: SquareFunction
 ---
 

--- a/docs/latest/3rd-parties/supabase.pl.mdx
+++ b/docs/latest/3rd-parties/supabase.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supabase
-description: Odświeżanie sesji Supabase wewnątrz łańcucha NEMO: ciasteczka trafiają do odpowiedzi, a kolejne funkcje widzą już zalogowanego użytkownika.
+description: "Odświeżanie sesji Supabase wewnątrz łańcucha NEMO: ciasteczka trafiają do odpowiedzi, a kolejne funkcje widzą już zalogowanego użytkownika."
 icon: SquareFunction
 ---
 

--- a/docs/latest/advanced-matching.mdx
+++ b/docs/latest/advanced-matching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Advanced Route Matching
-description: Beyond plain paths: restrict a parameter to a set of values, exclude specific ones, and fall back to regular expressions when a pattern needs it.
+description: "Beyond plain paths: restrict a parameter to a set of values, exclude specific ones, and fall back to regular expressions when a pattern needs it."
 icon: Variable
 ---
 

--- a/docs/latest/advanced-matching.mdx
+++ b/docs/latest/advanced-matching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Advanced Route Matching
-description: Learn advanced patterns for route matching in NEMO
+description: Beyond plain paths: restrict a parameter to a set of values, exclude specific ones, and fall back to regular expressions when a pattern needs it.
 icon: Variable
 ---
 

--- a/docs/latest/advanced-matching.pl.mdx
+++ b/docs/latest/advanced-matching.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zaawansowane dopasowywanie tras
-description: Ograniczanie parametrów do listy wartości, wykluczenia i wyrażenia regularne we wzorcach NEMO
+description: Nie tylko kształt ścieżki: lista dopuszczalnych wartości parametru, wykluczanie konkretnych oraz wyrażenia regularne, gdy wzorzec nie wystarcza.
 icon: Variable
 ---
 

--- a/docs/latest/advanced-matching.pl.mdx
+++ b/docs/latest/advanced-matching.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zaawansowane dopasowywanie tras
-description: Nie tylko kształt ścieżki: lista dopuszczalnych wartości parametru, wykluczanie konkretnych oraz wyrażenia regularne, gdy wzorzec nie wystarcza.
+description: "Nie tylko kształt ścieżki: lista dopuszczalnych wartości parametru, wykluczanie konkretnych oraz wyrażenia regularne, gdy wzorzec nie wystarcza."
 icon: Variable
 ---
 

--- a/docs/latest/best-practices.mdx
+++ b/docs/latest/best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: Best practices
-description: Best practices for developing Next.js middleware
+description: Middleware runs before every request, so each millisecond lands in TTFB. Performance, security and reliability practices for a production chain.
 icon: ThumbsUp
 ---
 

--- a/docs/latest/best-practices.pl.mdx
+++ b/docs/latest/best-practices.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dobre praktyki
-description: Wydajność, bezpieczeństwo i niezawodność middleware w projektach Next.js
+description: Middleware wykonuje się przed każdym żądaniem, więc każda milisekunda ląduje w TTFB. Wydajność, bezpieczeństwo i niezawodność łańcucha.
 icon: ThumbsUp
 ---
 

--- a/docs/latest/configuration.mdx
+++ b/docs/latest/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Learn how to configure NEMO middleware
+description: The three arguments of createNEMO: the route map, global middleware that runs on every request, and the options that change how the chain behaves.
 icon: Settings
 ---
 

--- a/docs/latest/configuration.mdx
+++ b/docs/latest/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: The three arguments of createNEMO: the route map, global middleware that runs on every request, and the options that change how the chain behaves.
+description: "The three arguments of createNEMO: the route map, global middleware that runs on every request, and the options that change how the chain behaves."
 icon: Settings
 ---
 

--- a/docs/latest/configuration.pl.mdx
+++ b/docs/latest/configuration.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Konfiguracja
-description: Trzy argumenty createNEMO: mapa tras, middleware globalne uruchamiane przy każdym żądaniu i opcje zmieniające zachowanie całego łańcucha.
+description: "Trzy argumenty createNEMO: mapa tras, middleware globalne uruchamiane przy każdym żądaniu i opcje zmieniające zachowanie całego łańcucha."
 icon: Settings
 ---
 

--- a/docs/latest/configuration.pl.mdx
+++ b/docs/latest/configuration.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Konfiguracja
-description: Mapa tras, middleware globalne i opcje biblioteki - trzy argumenty createNEMO
+description: Trzy argumenty createNEMO: mapa tras, middleware globalne uruchamiane przy każdym żądaniu i opcje zmieniające zachowanie całego łańcucha.
 icon: Settings
 ---
 

--- a/docs/latest/context.mdx
+++ b/docs/latest/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Share data between functions in one chain: fetch the user once in an early function and read it from storage in every function that runs after it.
+description: "Share data between functions in one chain: fetch the user once in an early function and read it from storage in every function that runs after it."
 icon: Waypoints
 ---
 

--- a/docs/latest/context.mdx
+++ b/docs/latest/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Storage between functions across the execution chain
+description: Share data between functions in one chain: fetch the user once in an early function and read it from storage in every function that runs after it.
 icon: Waypoints
 ---
 

--- a/docs/latest/context.pl.mdx
+++ b/docs/latest/context.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Wspólne miejsce na dane w obrębie jednego żądania: użytkownika pobierasz raz, a kolejne funkcje w łańcuchu czytają go już ze storage.
+description: "Wspólne miejsce na dane w obrębie jednego żądania: użytkownika pobierasz raz, a kolejne funkcje w łańcuchu czytają go już ze storage."
 icon: Waypoints
 ---
 

--- a/docs/latest/context.pl.mdx
+++ b/docs/latest/context.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Wspólne miejsce na dane dzielone przez funkcje w łańcuchu wykonania
+description: Wspólne miejsce na dane w obrębie jednego żądania: użytkownika pobierasz raz, a kolejne funkcje w łańcuchu czytają go już ze storage.
 icon: Waypoints
 ---
 

--- a/docs/latest/conventions/functions-naming.mdx
+++ b/docs/latest/conventions/functions-naming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions naming
-description: Naming conventions for middleware functions
+description: Why middleware is the one word to keep out of a middleware function name, and how to name a dozen of them so the entry file still reads clearly.
 icon: SquareFunction
 ---
 

--- a/docs/latest/conventions/functions-naming.pl.mdx
+++ b/docs/latest/conventions/functions-naming.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nazewnictwo funkcji
-description: Konwencja nazw dla funkcji middleware w projekcie
+description: Dlaczego słowo middleware to jedyne, którego nie warto wstawiać w nazwę funkcji, i jak nazwać kilkanaście z nich, by plik wejściowy dało się czytać.
 icon: SquareFunction
 ---
 

--- a/docs/latest/conventions/project-structure.mdx
+++ b/docs/latest/conventions/project-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Project structure
-description: Project structure and organization proposal
+description: NEMO collects configuration in one entry file, but nothing says the function bodies belong there too. Where to put them as an application grows.
 icon: Folder
 ---
 

--- a/docs/latest/conventions/project-structure.pl.mdx
+++ b/docs/latest/conventions/project-structure.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Struktura projektu
-description: Propozycja rozmieszczenia funkcji middleware w drzewie katalogów aplikacji
+description: NEMO zbiera konfigurację w jednym pliku, ale ciała funkcji nie muszą tam leżeć. Gdzie je umieścić, żeby rosnąca aplikacja pozostała czytelna.
 icon: Folder
 ---
 

--- a/docs/latest/functions.mdx
+++ b/docs/latest/functions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions
-description: Middleware functions standardization, explanation and usage
+description: A NEMO middleware function has the same signature as a native Next.js one, so third-party functions drop straight in. Headers, events and returns.
 icon: Play
 ---
 

--- a/docs/latest/functions.pl.mdx
+++ b/docs/latest/functions.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Funkcje middleware
-description: Sygnatura funkcji, przekazywanie nagłówków w głąb aplikacji i rozszerzenia obiektu event
+description: Sygnatura taka sama jak w natywnym middleware Next.js, więc gotowe funkcje z zewnętrznych pakietów wchodzą bez adaptera. Nagłówki i obiekt event.
 icon: Play
 ---
 

--- a/docs/latest/index.mdx
+++ b/docs/latest/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Supercharge your Next.js middleware with NEMO
+description: Install @zanreal/nemo, import it in middleware.ts and dispatch your first routes - the short path from an empty file to a working chain.
 icon: Book
 ---
 

--- a/docs/latest/index.pl.mdx
+++ b/docs/latest/index.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pierwsze kroki
-description: Instalacja NEMO i pierwsza konfiguracja middleware w projekcie Next.js
+description: Instalacja pakietu, import w pliku middleware i pierwsza mapa tras - droga od pustego pliku do działającego łańcucha w kilka minut.
 icon: Book
 ---
 

--- a/docs/latest/matcher.mdx
+++ b/docs/latest/matcher.mdx
@@ -1,6 +1,6 @@
 ---
 title: Route matchers
-description: path-to-regexp matchers for middleware functions
+description: NEMO matches routes with path-to-regexp, the same syntax Next.js uses - named parameters, wildcards, and how matched values reach your functions.
 icon: Variable
 ---
 

--- a/docs/latest/matcher.pl.mdx
+++ b/docs/latest/matcher.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dopasowywanie tras
-description: Wzorce path-to-regexp, po których NEMO przypisuje funkcje do ścieżek
+description: Wzorce path-to-regexp, tej samej składni używa Next.js - parametry nazwane, wildcardy i to, jak dopasowane wartości trafiają do funkcji.
 icon: Variable
 ---
 

--- a/docs/latest/migration.mdx
+++ b/docs/latest/migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating to @zanreal/nemo
-description: NEMO moved from the @rescale npm scope to @zanreal in v3.0.0 - here is what changes for you
+description: NEMO is published as @zanreal/nemo from v3.0.0. The API is unchanged - same exports, same signatures - so migrating is a rename and a codemod.
 icon: PackageOpen
 ---
 

--- a/docs/latest/nesting.mdx
+++ b/docs/latest/nesting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nested Routes
-description: How to work with nested routes in NEMO middleware
+description: Arrange middleware in a hierarchy that mirrors your route tree - execution order, stopping the chain early, and reading params from higher levels.
 icon: GitFork
 ---
 

--- a/docs/latest/nesting.pl.mdx
+++ b/docs/latest/nesting.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trasy zagnieżdżone
-description: Hierarchia middleware w NEMO - kolejność wykonania, przerywanie łańcucha i parametry z wyższych poziomów
+description: Hierarchia middleware odwzorowująca drzewo tras: kolejność wykonania, przerywanie łańcucha i parametry przejmowane z wyższych poziomów.
 icon: GitFork
 ---
 

--- a/docs/latest/nesting.pl.mdx
+++ b/docs/latest/nesting.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trasy zagnieżdżone
-description: Hierarchia middleware odwzorowująca drzewo tras: kolejność wykonania, przerywanie łańcucha i parametry przejmowane z wyższych poziomów.
+description: "Hierarchia middleware odwzorowująca drzewo tras: kolejność wykonania, przerywanie łańcucha i parametry przejmowane z wyższych poziomów."
 icon: GitFork
 ---
 

--- a/docs/latest/stewardship.mdx
+++ b/docs/latest/stewardship.mdx
@@ -1,6 +1,6 @@
 ---
 title: ZanReal OSS Program
-description: NEMO is now maintained by ZanReal as part of its OSS Program - what that means for you
+description: NEMO started in 2024 as one developer's answer to a gap in Next.js middleware. ZanReal maintains it now, and this is what that changes for you.
 icon: Building2
 ---
 

--- a/docs/latest/stewardship.pl.mdx
+++ b/docs/latest/stewardship.pl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Program OSS ZanReal
-description: Opiekę nad NEMO przejął ZanReal w ramach firmowego programu OSS - co się przez to zmienia dla Ciebie
+description: NEMO powstało w 2024 roku jako odpowiedź na lukę w middleware Next.js. Dziś opiekę nad projektem sprawuje ZanReal - co to zmienia dla Ciebie.
 icon: Building2
 ---
 

--- a/docs/v1/api-reference/supabase.mdx
+++ b/docs/v1/api-reference/supabase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supabase
-description: NEMO middleware functions for Supabase
+description: Supabase integration as documented on the v1.4 line, using @rescale/nemo. Newer majors cover the same ground under their 3rd-parties section.
 icon: SquareFunction
 ---
 

--- a/docs/v1/configuration.mdx
+++ b/docs/v1/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Package configuration and explanation
+description: createMiddleware on the v1.4 line: the entry point that turns a path-keyed map into one Next.js middleware export. Legacy documentation.
 icon: Wrench
 ---
 

--- a/docs/v1/configuration.mdx
+++ b/docs/v1/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: createMiddleware on the v1.4 line: the entry point that turns a path-keyed map into one Next.js middleware export. Legacy documentation.
+description: "createMiddleware on the v1.4 line: the entry point that turns a path-keyed map into one Next.js middleware export. Legacy documentation."
 icon: Wrench
 ---
 

--- a/docs/v1/context.mdx
+++ b/docs/v1/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shared context
-description: Shared context between functions across the execution chain
+description: Shared context on the v1.4 line let functions in one chain pass data between each other. Superseded by storage in the majors that followed.
 icon: Waypoints
 ---
 

--- a/docs/v1/conventions/functions-naming.mdx
+++ b/docs/v1/conventions/functions-naming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions naming
-description: Naming conventions for middleware functions
+description: Naming conventions for middleware functions on the v1.4 line, kept as published for projects that have not yet migrated to a newer major.
 icon: SquareFunction
 ---
 

--- a/docs/v1/conventions/project-structure.mdx
+++ b/docs/v1/conventions/project-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Project structure
-description: Project structure and organization proposal
+description: How the v1.4 line suggested organising middleware across a project's directories, kept for reference alongside the current guidance.
 icon: Folder
 ---
 

--- a/docs/v1/forward-functions.mdx
+++ b/docs/v1/forward-functions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Forward
-description: Documentation for forward functions in NEMO
+description: Forward functions on the v1.4 line pass one middleware's response into the next, chaining behaviour across a request. Legacy documentation.
 icon: ArrowRight
 ---
 

--- a/docs/v1/functions.mdx
+++ b/docs/v1/functions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions
-description: Middleware functions standardization, explanation and usage
+description: Middleware function standardisation as it worked on the v1.4 line, before the API moved to the native Next.js signature in later majors.
 icon: Play
 ---
 

--- a/docs/v1/index.mdx
+++ b/docs/v1/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Supercharge your Next.js middleware with NEMO
+description: Getting started on the v1.4 line, published as @rescale/nemo. Kept for existing projects - new work should start on the current major instead.
 icon: Book
 ---
 

--- a/docs/v1/matcher.mdx
+++ b/docs/v1/matcher.mdx
@@ -1,6 +1,6 @@
 ---
 title: Route matchers
-description: path-to-regexp matchers for middleware functions
+description: Route matching on the v1.4 line with path-to-regexp - patterns, named parameters, and how matched values reached your middleware functions.
 icon: Variable
 ---
 

--- a/docs/v2/3rd-parties/next-auth.mdx
+++ b/docs/v2/3rd-parties/next-auth.mdx
@@ -1,6 +1,6 @@
 ---
 title: NextAuth (Auth.js)
-description: NEMO middleware functions for NextAuth (Auth.js)
+description: Integrating Auth.js with a NEMO v2 chain so the resolved session is shared with every function that runs after it within the same request.
 icon: SquareFunction
 ---
 

--- a/docs/v2/3rd-parties/supabase.mdx
+++ b/docs/v2/3rd-parties/supabase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supabase
-description: NEMO middleware functions for Supabase
+description: Integrating Supabase session refresh with a NEMO v2 chain so refreshed cookies reach the response and later functions see the signed-in user.
 icon: SquareFunction
 ---
 

--- a/docs/v2/advanced-matching.mdx
+++ b/docs/v2/advanced-matching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Advanced Route Matching
-description: Advanced v2 patterns: restrict a parameter to a set of values, exclude specific ones, and drop to a regular expression when a pattern needs more.
+description: "Advanced v2 patterns: restrict a parameter to a set of values, exclude specific ones, and drop to a regular expression when a pattern needs more."
 icon: Variable
 ---
 

--- a/docs/v2/advanced-matching.mdx
+++ b/docs/v2/advanced-matching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Advanced Route Matching
-description: Learn advanced patterns for route matching in NEMO
+description: Advanced v2 patterns: restrict a parameter to a set of values, exclude specific ones, and drop to a regular expression when a pattern needs more.
 icon: Variable
 ---
 

--- a/docs/v2/best-practices.mdx
+++ b/docs/v2/best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: Best practices
-description: Best practices for developing Next.js middleware
+description: Practices for a v2 middleware chain in production - keeping execution time out of TTFB, handling secrets carefully, and failing safely at scale.
 icon: ThumbsUp
 ---
 

--- a/docs/v2/configuration.mdx
+++ b/docs/v2/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Learn how to configure NEMO middleware
+description: How createNEMO is configured on the v2 line - the route map, middleware that runs globally, and the options that change the chain's behaviour.
 icon: Settings
 ---
 

--- a/docs/v2/context.mdx
+++ b/docs/v2/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Storage between functions across the execution chain
+description: Storage on the v2 line: share data across a single chain so a value fetched in an early function is readable by every function that follows it.
 icon: Waypoints
 ---
 

--- a/docs/v2/context.mdx
+++ b/docs/v2/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Storage on the v2 line: share data across a single chain so a value fetched in an early function is readable by every function that follows it.
+description: "Storage on the v2 line: share data across a single chain so a value fetched in an early function is readable by every function that follows it."
 icon: Waypoints
 ---
 

--- a/docs/v2/conventions/functions-naming.mdx
+++ b/docs/v2/conventions/functions-naming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions naming
-description: Naming conventions for middleware functions
+description: Naming middleware functions on the v2 line so an entry file holding a dozen of them stays readable - and why middleware is not part of a name.
 icon: SquareFunction
 ---
 

--- a/docs/v2/conventions/project-structure.mdx
+++ b/docs/v2/conventions/project-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Project structure
-description: Project structure and organization proposal
+description: Where middleware function bodies live on the v2 line once configuration is centralised in one entry file, and how that arrangement scales up.
 icon: Folder
 ---
 

--- a/docs/v2/functions.mdx
+++ b/docs/v2/functions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Functions
-description: Middleware functions standardization, explanation and usage
+description: Middleware functions on the v2 line use the native Next.js signature, so third-party functions drop in unchanged. Headers, events and returns.
 icon: Play
 ---
 

--- a/docs/v2/index.mdx
+++ b/docs/v2/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Getting started on the NEMO v2 line: install the package, import it in your middleware file and dispatch the first routes from one entry point.
+description: "Getting started on the NEMO v2 line: install the package, import it in your middleware file and dispatch the first routes from one entry point."
 icon: Book
 ---
 

--- a/docs/v2/index.mdx
+++ b/docs/v2/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Supercharge your Next.js middleware with NEMO
+description: Getting started on the NEMO v2 line: install the package, import it in your middleware file and dispatch the first routes from one entry point.
 icon: Book
 ---
 

--- a/docs/v2/matcher.mdx
+++ b/docs/v2/matcher.mdx
@@ -1,6 +1,6 @@
 ---
 title: Route matchers
-description: path-to-regexp matchers for middleware functions
+description: Route matching on the v2 line uses path-to-regexp - patterns, named parameters, and how matched values are passed into your middleware functions.
 icon: Variable
 ---
 

--- a/docs/v2/migration.mdx
+++ b/docs/v2/migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating to @zanreal/nemo
-description: NEMO moved from the @rescale npm scope to @zanreal in v3.0.0 - here is what changes for you
+description: Moving from @rescale/nemo to @zanreal/nemo: the v3.0.0 scope change with an unchanged API, and the codemod that rewrites the imports for you.
 icon: PackageOpen
 ---
 

--- a/docs/v2/migration.mdx
+++ b/docs/v2/migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating to @zanreal/nemo
-description: Moving from @rescale/nemo to @zanreal/nemo: the v3.0.0 scope change with an unchanged API, and the codemod that rewrites the imports for you.
+description: "Moving from @rescale/nemo to @zanreal/nemo: the v3.0.0 scope change with an unchanged API, and the codemod that rewrites the imports for you."
 icon: PackageOpen
 ---
 

--- a/docs/v2/nesting.mdx
+++ b/docs/v2/nesting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nested Routes
-description: How to work with nested routes in NEMO middleware
+description: Nested routes on the v2 line: build a middleware hierarchy that mirrors your route tree, control execution order and stop the chain when needed.
 icon: GitFork
 ---
 

--- a/docs/v2/nesting.mdx
+++ b/docs/v2/nesting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nested Routes
-description: Nested routes on the v2 line: build a middleware hierarchy that mirrors your route tree, control execution order and stop the chain when needed.
+description: "Nested routes on the v2 line: build a middleware hierarchy that mirrors your route tree, control execution order and stop the chain when needed."
 icon: GitFork
 ---
 


### PR DESCRIPTION
Ahrefs is reporting meta descriptions outside the ~110-160 character range across the documentation. **51 of 52 pages** were under it, most between 38 and 60 characters:

| Page | Before | Length |
|---|---|---|
| `latest/configuration` | Learn how to configure NEMO middleware | 38 |
| `latest/3rd-parties/supabase` | NEMO middleware functions for Supabase | 38 |
| `v1/configuration` | Package configuration and explanation | 37 |
| `latest/conventions/project-structure` | Project structure and organization proposal | 43 |

They read as sidebar subtitles, which is what they were written as. They are also what Google prints under the link, and at 38 characters the result renders as a title with almost nothing beneath it.

## Each version line gets its own wording

`v1`, `v2` and `latest` document the same concepts on near-identical pages. One description reused across them would put **identical meta on three indexed URLs**, and leave a searcher unable to tell which major they had landed on:

```
latest/configuration  The three arguments of createNEMO: the route map, global middleware that
                      runs on every request, and the options that change how the chain behaves.

v2/configuration      How createNEMO is configured on the v2 line - the route map, middleware
                      that runs globally, and the options that change the chain's behaviour.

v1/configuration      createMiddleware on the v1.4 line: the entry point that turns a path-keyed
                      map into one Next.js middleware export. Legacy documentation.
```

The `v1` descriptions name the version and the `@rescale/nemo` scope outright - that line is kept for projects that have not migrated, and someone arriving from a search result should be able to tell it is not current.

## Polish

The Polish descriptions are written in Polish, not translated from the English beside them, and pick different details where a different detail reads better. Translated copy imports the source language's sentence rhythm and misses the phrases people actually search in that language.

## Verification

- All 52 pages fall between 110 and 160 characters.
- All 52 descriptions are unique.
- No em or en dashes.
- Frontmatter parses on every page; only the `description` field is touched, and no page body changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)