### PR TITLE
docs: link the ZanReal OSS program page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,8 +23,8 @@ export const middleware = createNEMO({
 
 <Callout title="Maintained by ZanReal as part of its OSS Program">
   NEMO is a company project rather than one person's side project: the package, the repository and
-  the release process belong to ZanReal, and the licence stays MIT. [What that
-  means](/docs/latest/stewardship).
+  the release process belong to ZanReal under its [OSS Program](https://zanreal.com/oss), and the
+  licence stays MIT. [What that means](/docs/latest/stewardship).
 </Callout>
 
 ## First, let the code get the word out

--- a/docs/index.pl.mdx
+++ b/docs/index.pl.mdx
@@ -24,7 +24,7 @@ export const middleware = createNEMO({
 <Callout title="Rozwijane przez ZanReal w ramach programu OSS">
   NEMO to projekt firmowy, a nie czyjeś zajęcie po godzinach: pakiet, repozytorium i proces
   wydawniczy należą do ZanReal, a licencja pozostaje MIT. [Co z tego
-  wynika](/docs/latest/stewardship).
+  wynika](/docs/latest/stewardship) i czym jest [program OSS](https://zanreal.com/pl/open-source).
 </Callout>
 
 ## Niech przemówi kod

--- a/docs/latest/stewardship.mdx
+++ b/docs/latest/stewardship.mdx
@@ -15,7 +15,8 @@ one person still having time for it.
 ## The takeover
 
 As of v3.0.0, NEMO is maintained by **[ZanReal](https://zanreal.com)** as part of the company's
-**OSS Program** - open source maintained as company work rather than someone's evenings:
+**[OSS Program](https://zanreal.com/oss)** - open source maintained as company work rather than
+someone's evenings:
 
 - The package is published as `@zanreal/nemo`, under the company's npm scope.
 - The repository lives in the [zanreal-labs](https://github.com/zanreal-labs) GitHub organisation.

--- a/docs/latest/stewardship.pl.mdx
+++ b/docs/latest/stewardship.pl.mdx
@@ -15,7 +15,8 @@ tym, czy jedna osoba nadal ma dla niego czas.
 ## Zmiana opiekuna
 
 Od wersji 3.0.0 NEMO utrzymuje **[ZanReal](https://zanreal.com)** w ramach firmowego
-**programu OSS**, czyli open source rozwijanego w godzinach pracy, a nie po nich:
+**[programu OSS](https://zanreal.com/pl/open-source)**, czyli open source rozwijanego w godzinach
+pracy, a nie po nich:
 
 - Pakiet wychodzi jako `@zanreal/nemo`, w firmowym scope npm.
 - Repozytorium mieszka w organizacji [zanreal-labs](https://github.com/zanreal-labs) na GitHubie.

--- a/packages/nemo/README.md
+++ b/packages/nemo/README.md
@@ -20,7 +20,7 @@ A middleware composition library for Next.js applications that allows you to org
   <img alt="ZanReal" src="https://cdn.zanreal.com/public/logo.svg" height="32" />
 </a>
 
-NEMO is maintained by [ZanReal](https://zanreal.com) as part of its OSS Program - see
+NEMO is maintained by [ZanReal](https://zanreal.com) as part of its [OSS Program](https://zanreal.com/oss) - see
 [project stewardship](https://zanreal.com/docs/oss/nemo/latest/stewardship) for what that means.
 
 ## Installation


### PR DESCRIPTION
The README already states that NEMO is maintained by ZanReal as part of its OSS Program, but the words "OSS Program" were plain text with nowhere to go, so a reader arriving from npm or GitHub had no way to find out what the program actually commits us to. This turns that phrase into a link to https://zanreal.com/oss, the page that describes it, and leaves the rest of the sentence, the stewardship link next to it, and every other line in the file untouched.

The same unlinked mention appeared in the docs tree, so this also links it in `docs/index.mdx` and `docs/latest/stewardship.mdx` plus their Polish twins, which matters more than the README does: those four files are pulled into zanreal.com by the marketing site's OSS docs sync and rendered under `/docs/oss/nemo`, so the link reaches readers on the site as well as on GitHub. The Polish pages point at `https://zanreal.com/pl/open-source` with natively inflected anchor text, and the URLs are absolute because these files render in both places and a relative `/oss` would break on GitHub. The two `<Callout title="...">` attributes keep their plain wording, since a JSX string attribute is not parsed as markdown; the link sits in the callout body instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
