### PR TITLE
ci: SonarCloud analysis with bun test coverage

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,21 +2,28 @@
 # included. Configuration lives in sonar-project.properties at the repository
 # root.
 #
-# SonarCloud's Automatic Analysis cannot read coverage reports - zanreal-labs_nemo
-# exposes an `ncloc` measure and no `coverage` measure at all, despite the suite
-# having produced an lcov for Codecov all along - so this workflow replaces it.
-# The two modes are mutually exclusive. Until Automatic Analysis is switched off,
-# the scanner rejects the submission with "You are running manual analysis while
-# Automatic Analysis is enabled", which is the expected intermediate state.
+# SonarCloud's Automatic Analysis cannot read coverage reports - the canary
+# branch of zanreal-labs_nemo exposes an `ncloc` measure and no `coverage`
+# measure at all, despite the suite having produced an lcov for Codecov all along
+# - so this workflow replaces it.
 #
-# The repository owner has to do two things, in this order:
+# SONAR_TOKEN is already set on this repository, left behind when #205 removed the
+# previous scanner workflow, so the scan runs as soon as this lands. One thing is
+# still outstanding for the repository owner:
 #
-#   1. gh secret set SONAR_TOKEN --repo zanreal-labs/nemo
-#   2. SonarCloud > zanreal-labs_nemo > Administration > Analysis Method, turn
-#      Automatic Analysis off.
+#   SonarCloud > zanreal-labs_nemo > Administration > Analysis Method, turn
+#   Automatic Analysis off.
 #
-# Before step 1 the Scan job self-skips and this workflow concludes successfully,
-# so nothing here can turn CI red while it is still unconfigured.
+# Do that before merging. Pull request analysis was empirically accepted with
+# Automatic Analysis still enabled - see the run on the pull request that added
+# this file - but the two modes are documented as mutually exclusive, and the
+# push-to-canary path is the one that would report "You are running manual
+# analysis while Automatic Analysis is enabled". Automatic Analysis also has to
+# go for the branch measures to gain coverage at all, which is the entire point.
+#
+# If SONAR_TOKEN is ever unset or rotated away, the Scan job self-skips and this
+# workflow concludes successfully rather than failing. Pull requests from forks
+# never receive the secret and take that path too.
 #
 # Codecov is untouched: the Tests workflow (codecov.yml) keeps running its own
 # `bun test` and uploading packages/nemo/coverage. The two systems share nothing
@@ -79,8 +86,12 @@ jobs:
       contents: read
 
     steps:
+      # v5 rather than the v4 the other workflows in this repository still use:
+      # v4 runs on Node.js 20, which GitHub has deprecated, and every run of it
+      # publishes a deprecation warning as a job annotation. v5.1.0 declares
+      # `using: node24`.
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # Sonar needs the full history to attribute blame and to resolve the new
           # code period; a shallow clone silently degrades both.

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,127 @@
+# SonarQube Cloud analysis, driven from CI so that bun's test coverage is
+# included. Configuration lives in sonar-project.properties at the repository
+# root.
+#
+# SonarCloud's Automatic Analysis cannot read coverage reports - zanreal-labs_nemo
+# exposes an `ncloc` measure and no `coverage` measure at all, despite the suite
+# having produced an lcov for Codecov all along - so this workflow replaces it.
+# The two modes are mutually exclusive. Until Automatic Analysis is switched off,
+# the scanner rejects the submission with "You are running manual analysis while
+# Automatic Analysis is enabled", which is the expected intermediate state.
+#
+# The repository owner has to do two things, in this order:
+#
+#   1. gh secret set SONAR_TOKEN --repo zanreal-labs/nemo
+#   2. SonarCloud > zanreal-labs_nemo > Administration > Analysis Method, turn
+#      Automatic Analysis off.
+#
+# Before step 1 the Scan job self-skips and this workflow concludes successfully,
+# so nothing here can turn CI red while it is still unconfigured.
+#
+# Codecov is untouched: the Tests workflow (codecov.yml) keeps running its own
+# `bun test` and uploading packages/nemo/coverage. The two systems share nothing
+# but the report path, and this job produces its own copy in its own runner.
+#
+# Leak-period gotcha, for whoever the quality gate first blocks: touching a line
+# that already contained a hotspot pulls that hotspot into your pull request's
+# new-code period, where it becomes yours to answer for. A cosmetic reformat is
+# enough to do it. Either fix the hotspot properly or leave the line alone.
+name: SonarQube
+
+on:
+  push:
+    branches: [canary, main]
+  pull_request:
+    branches: [canary, main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Secrets cannot be read from a job-level `if:`, so token presence is probed in
+  # a job of its own and the scan depends on its output. A missing SONAR_TOKEN is
+  # a configuration state, not a broken pull request: the scan is skipped, never
+  # failed. Pull requests from forks never receive the secret, so this is also
+  # what keeps contributor pull requests green.
+  guard:
+    name: Check configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Least privilege, declared per job as Sonar's githubactions:S8264 asks. This
+    # job touches nothing but its own step output.
+    permissions: {}
+    outputs:
+      has_token: ${{ steps.token.outputs.has_token }}
+
+    steps:
+      - name: Detect SONAR_TOKEN
+        id: token
+        env:
+          HAS_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
+        run: |
+          echo "has_token=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
+          if [ "$HAS_TOKEN" != "true" ]; then
+            echo "::notice title=SonarQube skipped::SONAR_TOKEN is not set on this repository, so no analysis was submitted. Set the secret to enable the scan."
+          fi
+
+  sonarqube:
+    name: Scan
+    needs: guard
+    if: needs.guard.outputs.has_token == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Read-only: the scan clones the repository and submits results to SonarQube
+    # Cloud with SONAR_TOKEN. Pull request decoration is posted by the SonarCloud
+    # GitHub App, not by this workflow's token, so no write scope is needed.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # Sonar needs the full history to attribute blame and to resolve the new
+          # code period; a shallow clone silently degrades both.
+          fetch-depth: 0
+
+      - name: Prepare
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      # --ignore-scripts keeps install lifecycle hooks out of the scan job, which
+      # is what Sonar's githubactions:S6505 asks for, and matches what the Tests
+      # workflow already does. Nothing on the coverage path needs them: the root
+      # `prepare` script only installs husky's git hooks.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Deliberately not continue-on-error. Coverage measured against a red suite
+      # is not worth publishing, so a failing test fails this workflow.
+      #
+      # This must run at the repository root. bun reads bunfig.toml from the
+      # working directory and does not walk up, so a per-package run produces no
+      # coverage at all; the root run instruments every package it loads and
+      # writes one lcov with repository-root-relative paths. The reporters are
+      # named explicitly rather than inherited from bunfig.toml so that this job
+      # cannot silently stop emitting lcov, and `text` is kept for the log.
+      - name: Run tests with coverage
+        run: bun test --coverage --coverage-reporter=text --coverage-reporter=lcov
+
+      # A missing report does not fail the scan. It publishes 0% coverage and
+      # quietly resets the baseline, which is worse, so fail loudly instead.
+      - name: Verify coverage report
+        run: |
+          report=packages/nemo/coverage/lcov.info
+          if [ ! -s "$report" ]; then
+            echo "::error title=No coverage report::$report is missing or empty. Check the coverageDir setting in bunfig.toml."
+            exit 1
+          fi
+          echo "$report covers $(grep -c '^SF:' "$report") source files."
+
+      - name: SonarQube scan
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        env:
+          # SONAR_HOST_URL is deliberately unset: the action targets SonarQube
+          # Cloud by default and only needs the URL for self-hosted servers.
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,130 @@
+# SonarQube Cloud configuration for the NEMO monorepo.
+#
+# History first, so this does not read as a revert of #206. The file deleted
+# there was dead config: nothing read it, because the scanner workflow that
+# would have was removed in #205, and it still declared the pre-rename
+# `z4nr34l_nemo` / `z4nr34l` keys while SonarCloud reported findings against
+# `zanreal-labs_nemo` in the `zanreal` organization and ignored the file
+# entirely. Its `sonar.sources` scoping was contradicted by the findings the app
+# actually raised, and its lcov paths were inert. This file is not that file
+# coming back. It carries the correct keys, it describes the tree as it is
+# today, and it has a consumer: .github/workflows/sonarqube.yml.
+#
+# Why CI analysis at all: Automatic Analysis cannot read coverage reports. The
+# project exposes an `ncloc` measure and no `coverage` measure whatsoever, even
+# though `bun test` has been producing an lcov for Codecov all along. The two
+# analysis modes are mutually exclusive, so Automatic Analysis has to be turned
+# off for zanreal-labs_nemo before the scanner is allowed to submit.
+#
+# The organization key is `zanreal`, not the GitHub org slug `zanreal-labs`.
+# Verified rather than assumed: the organizations/search API returns exactly one
+# organization for the pair `zanreal,zanreal-labs`, and that one is `zanreal`.
+# Project keys do carry the GitHub prefix, and the quality gate badge in
+# README.md already points at zanreal-labs_nemo.
+sonar.projectKey=zanreal-labs_nemo
+sonar.organization=zanreal
+sonar.sourceEncoding=UTF-8
+
+# Only the published packages are analysed. Everything else is out of scope by
+# omission rather than by exclusion, so that this file holds no entry that
+# matches nothing:
+#
+#   apps/docs  the documentation moved to zanreal.com/docs/oss/nemo and this app
+#              is now a redirect shim. next.config.mjs carries the redirect
+#              table; app/layout.tsx and app/page.tsx exist only because Next.js
+#              refuses to build without a root layout and a page.
+#   docs/      MDX content and its meta.json sidebars, not code.
+#   .github/   workflow files are not indexed here. Note the consequence: the
+#              GitHub Actions rules that Sonar types as vulnerabilities will not
+#              be raised once this scan replaces Automatic Analysis. The new
+#              workflow is hardened for them anyway.
+sonar.sources=packages
+sonar.tests=packages
+
+# packages/nemo is the library and keeps its code in src/. Neither of the other
+# two published packages has a src/ tree, so `packages/*/src/**` alone would
+# leave both unanalysed and would silently drop three of the eleven files in the
+# lcov report:
+#
+#   packages/codemod       a jscodeshift CLI shipped as plain ESM. Its `files`
+#                          field publishes exactly bin/, lib/ and transforms/.
+#   packages/rescale-nemo  the deprecated @rescale/nemo alias: three one-line
+#                          `export * from "@zanreal/nemo"` re-exports.
+sonar.inclusions=\
+  packages/*/src/**, \
+  packages/codemod/bin/**, \
+  packages/codemod/lib/**, \
+  packages/codemod/transforms/**, \
+  packages/rescale-nemo/index.js, \
+  packages/rescale-nemo/storage/**
+
+sonar.test.inclusions=\
+  **/__tests__/**, \
+  **/*.test.ts
+
+# The test globs are repeated in sonar.exclusions on purpose. A file matching
+# both the main and the test file set is indexed twice and the scanner fails
+# hard on that. Nothing under src/ or under codemod's bin/lib/transforms is a
+# test today, so this is what keeps a future colocated *.test.ts from breaking
+# the scan rather than merely being analysed in the wrong role.
+#
+# The generated directories listed are the ones that actually appear under
+# packages/: dist/ from tsup, coverage/ from bun, .turbo/ from turbo. There is no
+# **/.next/** entry because no Next.js app lives here - apps/docs is the only one
+# and it is not in sonar.sources. **/*.d.ts is load-bearing: it is what keeps
+# packages/rescale-nemo's three hand-written declaration files out of the main
+# set, since `packages/rescale-nemo/storage/**` would otherwise pull them in.
+sonar.exclusions=\
+  **/node_modules/**, \
+  **/dist/**, \
+  **/.turbo/**, \
+  **/coverage/**, \
+  **/*.d.ts, \
+  **/*.test.ts, \
+  **/__tests__/**
+
+sonar.test.exclusions=\
+  **/node_modules/**, \
+  **/dist/**, \
+  **/.turbo/**, \
+  **/coverage/**
+
+# One report for the whole monorepo, and its path is deliberately
+# counterintuitive. `bun test` runs from the repository root, instruments every
+# package it loads, and bunfig.toml pins `coverageDir = "packages/nemo/coverage"`
+# - a path left over from when nemo was the only package. So this single file
+# carries coverage for packages/nemo and packages/codemod alike.
+#
+# No path rewriting is needed. bun writes SF entries relative to the repository
+# root (`SF:packages/nemo/src/index.ts`), which is exactly what the scanner
+# resolves against sonar.projectBaseDir. Verified: all 11 SF entries resolve to
+# real files from the root, and all 11 fall inside sonar.inclusions.
+#
+# Running `bun test` inside a package instead yields no coverage at all: bun
+# reads bunfig.toml from the working directory and does not walk up, so
+# `coverage = true` never applies. The root run is the only coverage path, which
+# is why the workflow runs it there and why there is nothing to merge.
+#
+# bun's lcov writer emits SF/DA/LF/LH/FNF/FNH but no BRDA records, so Sonar will
+# report line coverage with no condition coverage. That is a property of the
+# reporter, not a gap in the suite.
+#
+# sonar.typescript.lcov.reportPaths is deliberately absent: SonarJS reads both
+# JavaScript and TypeScript coverage from this one property. The deleted file
+# set both, which was one of the ways it showed its age.
+sonar.javascript.lcov.reportPaths=packages/nemo/coverage/lcov.info
+
+# Re-export barrels only. bun emits nothing for them into the lcov because there
+# is nothing to execute, so leaving them in would count them as uncovered files
+# and present gaps that no test could ever close. packages/rescale-nemo is
+# guarded at the manifest level instead, by its __tests__/manifest.test.ts,
+# which is what actually broke for consumers when the alias shipped a
+# `workspace:^` specifier.
+sonar.coverage.exclusions=\
+  packages/nemo/src/storage/index.ts, \
+  packages/rescale-nemo/index.js, \
+  packages/rescale-nemo/storage/**
+
+# No sonar.cpd.exclusions. The sibling zanreal-web config carries some for
+# Next.js route scaffolding and per-locale metadata blocks; neither pattern
+# exists here, and an entry that matches nothing is how the last file rotted.


### PR DESCRIPTION
Moves `zanreal-labs_nemo` off SonarCloud's Automatic Analysis and onto a CI-driven scan fed by the coverage `bun test` already produces. Automatic Analysis cannot read coverage reports at all, which is the whole reason for the switch. Mirrors the pattern landed for `zanreal-labs/web` in zanreal-labs/web#531, adapted to bun.

## This is not a revert of #206

`sonar-project.properties` was deleted three commits ago (#206) as dead config, so its return needs explaining. The deleted file and this one have nothing in common but the filename:

| | deleted in #206 | added here |
| --- | --- | --- |
| Consumer | none - the scanner workflow was removed in #205 | `.github/workflows/sonarqube.yml` |
| Project key | `z4nr34l_nemo` (pre-rename) | `zanreal-labs_nemo` |
| Organization | `z4nr34l` (pre-rename) | `zanreal` |
| Scoping | contradicted the findings the app actually raised | matches the tree as it is today, verified file by file |
| lcov | two properties, one deprecated, both inert | one property, one report, ingestion verified |

#206 was right to delete it. The file was unread, its keys predated the organization rename, and it declared `sonar.project.monorepo.enabled` and `sonar.typescript.lcov.reportPaths`, neither of which does anything on this project. What it was missing was not correctness, it was a consumer. This adds the consumer first and then writes the configuration to match.

## Coverage findings for a bun monorepo

The interesting part is how different this is from the vitest setup in `web`, where sixteen workspaces each write their own report and the paths have to be rewritten before the scanner can resolve them. Under bun none of that applies.

**One report, and the path is deliberately counterintuitive.** `bunfig.toml` already pins `coverage = true`, `coverageReporter = ["text","lcov"]` and `coverageDir = "packages/nemo/coverage"` - a path left over from when nemo was the only package. `bun test` at the repository root instruments every package it loads, so that single file carries coverage for `packages/nemo` **and** `packages/codemod`. Eleven `SF:` entries across two packages in one report.

**No path normalization is needed.** bun writes `SF:` entries relative to the repository root (`SF:packages/nemo/src/index.ts`), which is exactly what the scanner resolves against `sonar.projectBaseDir`. Verified: all 11 entries resolve to real files from the root, and all 11 fall inside `sonar.inclusions`. The `scripts/normalize-lcov-paths.mjs` equivalent from the `web` PR has no counterpart here.

**Per-package runs produce no coverage whatsoever.** `cd packages/nemo && bun test` runs 224 tests and writes nothing - no report, not even a coverage table in the log. bun reads `bunfig.toml` from the working directory and does not walk up, so `coverage = true` never applies. The root run is the only coverage path, which is why the workflow runs it there and why there is nothing to merge or shard.

**bun's lcov has no branch data.** The writer emits `SF`/`DA`/`LF`/`LH`/`FNF`/`FNH` and no `BRDA` records, so Sonar will report line coverage with no condition coverage. That is a property of the reporter, not a gap in the suite.

**`packages/*/src/**` alone would have been wrong.** Only `packages/nemo` has a `src/` tree. `packages/codemod` ships plain ESM from `bin/`, `lib/` and `transforms/` - exactly the three directories in its `files` field - and `packages/rescale-nemo` is three one-line re-exports at the package root. Scoping to `src/` would have left a published CLI unanalysed and silently dropped three of the eleven lcov entries, since the scanner ignores coverage for files it has not indexed. All three published packages are in scope.

## Scoping

`sonar.sources=packages`. Everything else is out by omission rather than by exclusion, so the file holds no entry that matches nothing - the failure mode that made the last one rot:

- **`apps/docs`** is a redirect shim now. `next.config.mjs` carries the redirect table; `app/layout.tsx` and `app/page.tsx` exist only because Next.js refuses to build without a root layout and a page. The documentation itself lives at zanreal.com/docs/oss/nemo.
- **`docs/`** is MDX content and `meta.json` sidebars, not code.
- **`.github/`** is not indexed. Worth stating plainly, because it is a behaviour change: Automatic Analysis scans the whole repository, so once this scan takes over, the GitHub Actions findings and any findings in `__tests__` and `apps/docs` will close as no longer present. Whole-repo `ncloc` drops from 1757 to the 15 indexed source files. The new workflow is hardened for Sonar's Actions rules anyway (see below), and CodeQL still covers this repository separately.

Four re-export barrels are indexed but coverage-excluded: `packages/nemo/src/storage/index.ts` and the three `packages/rescale-nemo` files. bun emits nothing for them because there is nothing to execute, so leaving them in would count them as uncovered and present gaps no test could close. `rescale-nemo` is guarded at the manifest level instead, by `__tests__/manifest.test.ts` - which is what actually broke for consumers when the alias shipped a `workspace:^` specifier.

Test globs appear in both `sonar.test.inclusions` and `sonar.exclusions` on purpose. A file matching both the main and the test file set is indexed twice and the scanner fails hard on it. Nothing under `src/` is a test today, so that entry is what keeps a future colocated `*.test.ts` from breaking the scan rather than merely being analysed in the wrong role.

## Workflow design

**Self-skipping on a missing secret.** Secrets cannot be read from a job-level `if:`, so a small `guard` job probes `secrets.SONAR_TOKEN != ''` through `env` and publishes the result as a job output. The scan job carries `needs: guard` plus `if: needs.guard.outputs.has_token == 'true'`. Without the secret - or on a pull request from a fork, which never gets one - the scan reports as _skipped_ with a GitHub notice and the run concludes successfully. Nothing about a missing secret can turn CI red, which matters more here than in `web` because this repository takes outside contributions. As it happens the secret is already present, so the guard is insurance against rotation and the fork case rather than the state this lands in.

**Tests are not `continue-on-error`.** Coverage measured against a red suite is not worth publishing, so a failing test fails this workflow. Confirmed the mechanics rather than assuming them: `bun test` exits 1 with a failing test and 0 clean.

**Reporters are named explicitly** on the command line rather than inherited from `bunfig.toml`, so the job cannot silently stop emitting lcov if that file is ever edited. `text` is kept alongside `lcov` for the log. Verified that repeating `--coverage-reporter` works and that both land in the same place.

**A `Verify coverage report` step fails loudly on a missing lcov.** A missing report does not fail the scan; it publishes 0% coverage and quietly resets the baseline, which is worse.

**Hardened for the Actions rules Sonar types as vulnerabilities**, so that this workflow does not cost the project its security rating if `.github` is ever brought into scope, and because it is correct regardless:

- `githubactions:S8264` wants token scope per job: `permissions: {}` on the guard, `contents: read` on the scan. Pull request decoration is posted by the SonarCloud GitHub App, not by this workflow's token.
- `githubactions:S6505` objects to a CI install that runs lifecycle hooks, so the install uses `--ignore-scripts` - which the Tests workflow already does. Safe here: the root `prepare` script only installs husky's git hooks, and nothing on the coverage path needs them.
- `githubactions:S7637` wants full-length commit SHAs. All three actions are pinned, each resolved through the GitHub API against its release tag. `actions/checkout` is pinned to **v5.1.0**, not the v4 the rest of this repository uses: v4 runs on Node.js 20, which GitHub has deprecated, and the first run of this workflow published a deprecation annotation because of it. Renovate's `helpers:pinGitHubActionDigests` is already enabled here, so the pins are maintained from now on.

**Runner is `ubuntu-latest`**, matching every existing workflow in this repository. `SONAR_HOST_URL` is deliberately unset: the action targets SonarQube Cloud by default and only needs the URL for self-hosted servers.

**Codecov is untouched.** `codecov.yml` keeps running its own `bun test` and uploading `packages/nemo/coverage`, and its `ignore` list still scopes the 100% project gate to the library alone. The two systems live in separate workflows with separate runners and share nothing but the report path. Note that they will disagree by design: Codecov reports the library at 100%, Sonar reports the library plus the codemod CLI, whose argv handling and process-exit paths sit around 92%.

## Owner checklist

**Two of the three steps turn out to be already done.** `SONAR_TOKEN` is already set on this repository, left behind when #205 removed the previous scanner workflow, so the Scan job did not self-skip on the first push to this branch - it ran, and it succeeded. What is left is one setting:

- [ ] **Disable Automatic Analysis** for `zanreal-labs_nemo`: project **Administration > Analysis Method**, turn off _Automatic Analysis_. **Do this before merging** (see the warning below).
- [ ] Optional, afterwards: once a real coverage baseline is visible on canary, consider adding a coverage condition to the quality gate.

### Why step 1 has to happen before merge

The two analysis modes are documented as mutually exclusive, and the empirical result here is more interesting than that: **SonarCloud accepted the manual pull request analysis with Automatic Analysis still enabled.** The scan on this branch reported `ANALYSIS SUCCESSFUL`, and the pull request now carries coverage. But that is the pull request path. The push-to-canary path is the one that would report `You are running manual analysis while Automatic Analysis is enabled`, and after merge this workflow runs on push to canary. Turning automatic mode off first avoids a red run on canary. It is also required for the branch measures to gain coverage at all, which is the entire point of the change: canary currently reports `ncloc=1757` across 47 files and no coverage measure whatsoever.

## Leak-period gotcha

Noted in the workflow header too, because it will surprise someone: **editing a line that already contained a hotspot pulls that hotspot into your pull request's new-code period**, where it becomes yours to answer for. A cosmetic reformat is enough to do it. Either fix the hotspot properly or leave such lines alone.

## Verification done locally

- Clean `bun install --frozen-lockfile --ignore-scripts` followed by `bun test`: **277 pass, 0 fail, 555 expect() calls, 21 files, ~1.2s**. Repeated with `--coverage --coverage-reporter=text --coverage-reporter=lcov` as the workflow runs it: same 277, both reporters, lcov at `packages/nemo/coverage/lcov.info`.
- Exit code checked both ways: 1 with a deliberately failing test injected, 0 once removed, and no stray files left behind.
- Per-package run measured, not assumed: `cd packages/nemo && bun test` runs 224 tests and produces no coverage output anywhere on disk.
- All 11 `SF:` entries confirmed to resolve to real files from the repository root.
- `sonar-project.properties` parsed with Java properties line-continuation semantics, then every glob evaluated against a real walk of `packages/`: **15 main files indexed, 21 test files indexed, zero indexed-twice collisions, zero lcov entries dropped, zero indexed main files lacking coverage without an explicit exclusion, zero exclusion globs matching nothing.** Ten glob-translation assertions checked separately, including that `dist/`, `.turbo/`, `coverage/`, `node_modules/` and `*.d.ts` are excluded and that a hypothetical colocated `src/*.test.ts` would be caught.
- Re-ran the same check after `tsup` had populated `packages/nemo/dist`, to confirm build output stays out of the index.
- Organization and project keys verified against the live API, not inferred: `organizations/search?organizations=zanreal,zanreal-labs` returns exactly one organization, `zanreal`; `measures/component?component=zanreal-labs_nemo` returns `ncloc=1757` and **no `coverage`, `line_coverage` or `tests` measure at all**, which is the direct evidence that Automatic Analysis ingests no coverage. The README quality gate badge already points at `zanreal-labs_nemo`.
- Workflow YAML parsed and structurally checked: job graph, guard output wiring, `if:` condition, per-job permissions, step list, all three SHA pins.
- `prettier --check` clean on the workflow; `.properties` has no prettier parser, as expected.
- No em or en dashes in either file.
- commitlint run against each commit message before committing; the repository's husky hooks ran normally, no `--no-verify` needed.

## Verified on real CI, not just locally

The first push to this branch ran the workflow end to end, which is why the header and the checklist above were corrected in a follow-up commit rather than left as written:

| | Result |
| --- | --- |
| `Check configuration` | pass in 2s, `HAS_TOKEN: true` |
| `Scan` | pass in 55s, `ANALYSIS SUCCESSFUL` / `EXECUTION SUCCESS` |
| Coverage ingested | **98.7%**, 1125 lines to cover, 15 uncovered |
| Quality gate on the pull request | **OK** - reliability, security, maintainability all rating 1, hotspots 100% reviewed |
| Analysis time | 24.9s scanner, 35.5s total |

So the lcov really is read, the paths really do resolve without rewriting, and the gate really does pass. The one blemish on that run was a Node.js 20 deprecation annotation from `actions/checkout@v4`; the follow-up commit pins v5.1.0, which declares `using: node24`. Every other workflow in this repository still uses `v4` and will keep publishing that warning until Renovate or a separate change moves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
