### PR TITLE
test: close the remaining coverage gaps

### DIFF
--- a/packages/codemod/__tests__/cli.test.ts
+++ b/packages/codemod/__tests__/cli.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const { parseArgs, findManifests, migrateManifests, main, DEFAULT_RANGE } = require("../bin/cli.js");
+const { parseArgs, findManifests, migrateManifests, main, runCli, DEFAULT_RANGE } =
+  require("../bin/cli.js");
+
+const CLI = path.join(import.meta.dir, "..", "bin", "cli.js");
 
 let fixture: string;
 
@@ -81,6 +85,17 @@ describe("findManifests", () => {
     const found = findManifests(fixture).map((f: string) => path.relative(fixture, f)).sort();
     expect(found).toEqual(["package.json", path.join("packages", "app", "package.json")]);
   });
+
+  // A directory that cannot be read is not a reason to abort the whole migration, so the walk
+  // swallows the error and keeps whatever it has found so far.
+  it("returns what it already found when a directory cannot be read", () => {
+    write("package.json", "{}");
+    const found = ["seed.json"];
+
+    expect(findManifests(path.join(fixture, "not-here"))).toEqual([]);
+    expect(findManifests(path.join(fixture, "not-here"), found)).toBe(found);
+    expect(found).toEqual(["seed.json"]);
+  });
 });
 
 describe("migrateManifests", () => {
@@ -134,6 +149,28 @@ describe("migrateManifests", () => {
     expect(read("package.json")).toContain("@zanreal/nemo");
   });
 
+  // The glob compiler is internal, so its branches are exercised through the flag that feeds
+  // it. One pattern per shape: `**/` spanning segments, `?` for a single character, `*` staying
+  // inside one segment, and the literal dot in `package.json` that has to be escaped before it
+  // reaches the RegExp - unescaped it would match any character and widen the pattern.
+  it("honours ?, single-star and literal-dot ignore patterns", () => {
+    const dependency = JSON.stringify({ dependencies: { "@rescale/nemo": "^2.0.0" } }, null, 2);
+    write("apps/web1/package.json", dependency);
+    write("vendor-acme/package.json", dependency);
+    write("keep/package.json", dependency);
+
+    const touched = migrateManifests([fixture], {
+      depRange: "^3.0.0",
+      dry: false,
+      ignorePattern: ["**/web?/package.json", "**/vendor-*/*.json"],
+    });
+
+    expect(touched).toHaveLength(1);
+    expect(read("apps/web1/package.json")).toContain("@rescale/nemo");
+    expect(read("vendor-acme/package.json")).toContain("@rescale/nemo");
+    expect(read("keep/package.json")).toContain("@zanreal/nemo");
+  });
+
   it("warns and continues past an unparseable manifest", () => {
     write("package.json", "{ this is not json");
     const original = console.warn;
@@ -149,20 +186,47 @@ describe("migrateManifests", () => {
 });
 
 describe("end to end", () => {
-  /** Runs main() with the given argv, capturing stdout instead of printing it. */
-  async function runCli(args: string[]): Promise<string> {
+  /** Runs `invoke` under the given argv, capturing stdout instead of printing it. */
+  async function withArgv(args: string[], invoke: () => Promise<void>): Promise<string> {
     const argv = process.argv;
     const log = console.log;
     const output: string[] = [];
     process.argv = ["node", "cli.js", ...args];
     console.log = (...parts: unknown[]) => output.push(parts.join(" "));
     try {
-      await main();
+      await invoke();
     } finally {
       console.log = log;
       process.argv = argv;
     }
     return output.join("\n");
+  }
+
+  const runMain = (args: string[]) => withArgv(args, main);
+
+  /**
+   * Replaces process.exit with a throw, so a call that would kill the test runner stops the
+   * function under test instead, and collects what it printed on the way out.
+   */
+  function stubExit() {
+    const exit = process.exit;
+    const errorLog = console.error;
+    const codes: number[] = [];
+    const errors: string[] = [];
+    // @ts-expect-error -- stubbed for the assertion, throws to stop main() early
+    process.exit = (code: number) => {
+      codes.push(code);
+      throw new Error("exited");
+    };
+    console.error = (...parts: unknown[]) => errors.push(parts.map(String).join(" "));
+    return {
+      codes,
+      errors,
+      restore() {
+        process.exit = exit;
+        console.error = errorLog;
+      },
+    };
   }
 
   it("migrates sources and the manifest in one run", async () => {
@@ -180,7 +244,7 @@ describe("end to end", () => {
     );
     write("untouched.ts", `export const note = "@rescale/nemo lives here as text";\n`);
 
-    await runCli([fixture]);
+    await runMain([fixture]);
 
     expect(read("proxy.ts")).toContain(`from "@zanreal/nemo"`);
     expect(read("lib/storage.ts")).toContain(`from "@zanreal/nemo/storage"`);
@@ -194,7 +258,7 @@ describe("end to end", () => {
     write("package.json", manifest);
     write("proxy.ts", proxy);
 
-    await runCli([fixture, "--dry"]);
+    await runMain([fixture, "--dry"]);
 
     expect(read("proxy.ts")).toBe(proxy);
     expect(read("package.json")).toBe(manifest);
@@ -205,7 +269,7 @@ describe("end to end", () => {
     write("package.json", manifest);
     write("proxy.ts", `import { createNEMO } from "@rescale/nemo";\n`);
 
-    await runCli([fixture, "--skip-manifests"]);
+    await runMain([fixture, "--skip-manifests"]);
 
     expect(read("proxy.ts")).toContain(`"@zanreal/nemo"`);
     expect(read("package.json")).toBe(manifest);
@@ -215,32 +279,84 @@ describe("end to end", () => {
     write("package.json", JSON.stringify({ dependencies: { next: "^15.0.0" } }, null, 2));
     write("proxy.ts", `export const proxy = () => {};\n`);
 
-    const output = await runCli([fixture]);
+    const output = await runMain([fixture]);
     expect(output).toContain("Nothing to migrate");
   }, 30_000);
 
   it("prints usage for --help", async () => {
-    const output = await runCli(["--help"]);
+    const output = await runMain(["--help"]);
     expect(output).toContain("Usage");
     expect(output).toContain("npx @zanreal/nemo-codemod");
   });
 
   it("exits non-zero for a path that does not exist", async () => {
-    const exit = process.exit;
-    const errorLog = console.error;
-    const codes: number[] = [];
-    // @ts-expect-error -- stubbed for the assertion, throws to stop main() early
-    process.exit = (code: number) => {
-      codes.push(code);
-      throw new Error("exited");
-    };
-    console.error = () => {};
+    const stub = stubExit();
     try {
-      await expect(runCli([path.join(fixture, "missing")])).rejects.toThrow("exited");
+      await expect(runMain([path.join(fixture, "missing")])).rejects.toThrow("exited");
     } finally {
-      process.exit = exit;
-      console.error = errorLog;
+      stub.restore();
     }
-    expect(codes).toEqual([1]);
+    expect(stub.codes).toEqual([1]);
+    expect(stub.errors.join("\n")).toContain("Path does not exist");
   });
+
+  it("exits non-zero when the arguments do not parse", async () => {
+    const stub = stubExit();
+    try {
+      await expect(runMain(["--nope"])).rejects.toThrow("exited");
+    } finally {
+      stub.restore();
+    }
+    expect(stub.codes).toEqual([1]);
+    expect(stub.errors.join("\n")).toContain("Unknown option: --nope");
+  });
+
+  // Half a migration is worse than none: the manifest must not start pointing at
+  // @zanreal/nemo while a source file is still importing @rescale/nemo.
+  it("leaves the manifest alone when a source file fails to transform", async () => {
+    const manifest = JSON.stringify({ dependencies: { "@rescale/nemo": "^2.1.0" } }, null, 2);
+    write("package.json", manifest);
+    // Unparseable, so jscodeshift counts it as an error rather than as an unchanged file. Its
+    // worker prints the parse failure on stderr while this test runs; that output is expected
+    // and comes from jscodeshift, not from a failing assertion.
+    write("broken.ts", `import { createNEMO from "@rescale/nemo";\n`);
+
+    const stub = stubExit();
+    try {
+      await expect(runMain([fixture])).rejects.toThrow("exited");
+    } finally {
+      stub.restore();
+    }
+
+    expect(stub.codes).toEqual([1]);
+    expect(stub.errors.join("\n")).toContain("could not be transformed");
+    expect(read("package.json")).toBe(manifest);
+  }, 30_000);
+
+  // The handler of last resort, for anything main() does not catch itself.
+  it("prints the error and exits non-zero when main() rejects", async () => {
+    write("keep.ts", `export const keep = 1;\n`);
+    // A package.json that is a dangling symlink. The walk lists it, because a symlink is not a
+    // directory and the name matches, and the read that follows throws ENOENT with nothing
+    // between it and the entry point.
+    fs.symlinkSync(path.join(fixture, "gone.json"), path.join(fixture, "package.json"));
+
+    const stub = stubExit();
+    try {
+      await expect(withArgv([fixture], runCli)).rejects.toThrow("exited");
+    } finally {
+      stub.restore();
+    }
+
+    expect(stub.codes).toEqual([1]);
+    expect(stub.errors.join("\n")).toContain("ENOENT");
+  }, 30_000);
+
+  // `require.main === module` is false when the suite imports the file, so this is the only
+  // check that running bin/cli.js as a program reaches the entry point at all.
+  it("runs as a program", () => {
+    const result = spawnSync(process.execPath, [CLI, "--help"], { encoding: "utf8" });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("npx @zanreal/nemo-codemod");
+  }, 30_000);
 });

--- a/packages/codemod/bin/cli.js
+++ b/packages/codemod/bin/cli.js
@@ -261,11 +261,19 @@ async function main() {
   console.log("  2. Review the diff and run your test suite");
 }
 
-if (require.main === module) {
-  main().catch((error) => {
+// The last-resort handler, named and exported instead of left inline in the `require.main`
+// guard, so the suite can drive it. Anything main() rejects with lands here: a manifest that
+// turns out to be a dangling symlink, a permission error mid-write, a bug. The raw error is
+// logged rather than error.message because at that point the stack is the useful part.
+async function runCli() {
+  try {
+    await main();
+  } catch (error) {
     console.error(error);
     process.exit(1);
-  });
+  }
 }
 
-module.exports = { main, parseArgs, findManifests, migrateManifests, DEFAULT_RANGE, HELP };
+if (require.main === module) runCli();
+
+module.exports = { main, runCli, parseArgs, findManifests, migrateManifests, DEFAULT_RANGE, HELP };


### PR DESCRIPTION
`packages/codemod/bin/cli.js` was the only file in the repository under 100% line coverage: 92.3%, 15 uncovered lines out of 194. Every other file already reported 100%, so this file alone is the difference between the 98.7% SonarCloud shows on canary and the 100% Codecov reports.

## The gap

Taken from the lcov report rather than from the Sonar UI - `DA:<line>,0` records for `packages/codemod/bin/cli.js`:

| Lines | What was untested |
| --- | --- |
| 98 | `findManifests()` swallowing a directory it cannot read |
| 129, 133, 135 | the glob compiler's `?`, single-star and escaped-literal branches |
| 202-203 | `main()` reporting an argv that does not parse |
| 233-238 | `main()` refusing to touch `package.json` after a failed transform |
| 265, 266, 268 | the top-level failure handler in the `require.main` guard |

## The tests

Six, all driving the real code paths:

- **`findManifests` on an unreadable root.** Asserts it returns the accumulator it was given, so a directory it cannot read costs nothing but that subtree.
- **`?`, single-star and literal-dot ignore patterns.** The glob compiler is internal, so this goes through `--ignore-pattern`, its only consumer, with one pattern per unexercised shape. The literal dot matters: unescaped, `package.json` would match `packageXjson` too.
- **An argv that does not parse.** `main()` with `--nope`, asserting on the message and the exit code.
- **A source file that fails to transform.** Writes an unparseable `.ts` next to a `package.json` that names `@rescale/nemo`, and asserts the manifest is byte-identical afterwards. This is the guard that stops a half-migrated project - manifest renamed, imports still pointing at the old package - from shipping. Note: jscodeshift's worker prints the parse failure on stderr while this test runs. That output is expected.
- **`main()` rejecting.** Reached with a `package.json` that is a dangling symlink: the walk lists it, because a symlink is not a directory and the name matches, and the read that follows throws ENOENT with nothing between it and the entry point.
- **`bin/cli.js` invoked as a program.** Spawns it with `--help` and checks the exit code and output.

## One source change

The inline `main().catch()` inside `if (require.main === module)` is now a named, exported `runCli()`. Behaviour is unchanged. It was unreachable from a test in its old form: an anonymous callback inside a branch that is false whenever the suite imports the file, and spawning a process to reach it yields no coverage, because the subprocess is not instrumented.

The spawn test is kept regardless of coverage - it is the only thing in the suite that proves the `require.main` guard fires at all.

## No exclusions

`sonar-project.properties` is untouched. Nothing here needed hiding: `packages/codemod/bin/cli.js` now reports 100% lines, and there are no remaining `DA:...,0` records anywhere in the report.

## Verification

```
bun test          # 283 pass (277 before), 0 fail
lcov              # LH == LF for every file; grep -c 'DA:.*,0$' → 0
```

`bun test` at the repository root, which is the only run that produces coverage - bun reads `bunfig.toml` from the working directory and does not walk up.

The three pre-existing eslint parse errors under `packages/codemod` (`Cannot find module 'next/babel'`) are unchanged by this branch; verified against a stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)