### PR TITLE
docs: name the package rather than its npm identifier

### DIFF
--- a/docs/meta.json
+++ b/docs/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "@zanreal/nemo",
+  "title": "NEMO",
   "description": "Compose Next.js middleware and dispatch it by path.",
   "pages": ["latest", "v2", "v1"]
 }

--- a/docs/meta.pl.json
+++ b/docs/meta.pl.json
@@ -1,5 +1,5 @@
 {
-  "title": "@zanreal/nemo",
+  "title": "NEMO",
   "description": "Middleware Next.js składane w jeden punkt wejścia i rozdzielane po ścieżkach.",
   "pages": ["latest", "v2", "v1"]
 }


### PR DESCRIPTION
The docs sidebar title came from `docs/meta.json` as `@zanreal/nemo`, so the sidebar showed an npm identifier rather than the project's name.

The house standard across our other package docs is to name the package: `Admin Kit`, `Allegro`, `Usage`, `Tinybird Sink`, `FX Pricing`, `Product Costs`. A functional name is written natively per locale; a brand keeps its name in both.

NEMO is a brand, so it stays identical in both locales. The all-caps styling is the project's own: every one of the 145 prose references to it in `docs/` is `NEMO`, in the Polish pages as much as the English ones, and the factory export is `createNEMO`.

Only the `title` field changed. `description` and `pages` are untouched, and no URL, slug or page id moves.
